### PR TITLE
libalsa-intf : Add function pcm_chk_underruns()

### DIFF
--- a/legacy/libalsa-intf/alsa_audio.h
+++ b/legacy/libalsa-intf/alsa_audio.h
@@ -146,6 +146,7 @@ int pcm_ready(struct pcm *pcm);
 struct pcm_status *pcm_get_status(struct pcm *pcm);
 int pcm_drop(struct pcm *pcm);
 int pcm drain(struct pcm *pcm);
+int pcm_chk_underruns(struct pcm *pcm);
 int mmap_buffer(struct pcm *pcm);
 u_int8_t *dst_address(struct pcm *pcm);
 int sync_ptr(struct pcm *pcm);

--- a/legacy/libalsa-intf/alsa_pcm.c
+++ b/legacy/libalsa-intf/alsa_pcm.c
@@ -902,3 +902,12 @@ int pcm_drain(struct pcm *pcm)
 
 	return 0;
 }
+
+int pcm_chk_underruns(struct pcm *pcm)
+{
+	int underruns;
+
+	underruns = pcm->underruns;
+
+	return underruns;
+}


### PR DESCRIPTION
When EPIPE error occure in pcm_write_mmap(),
pcm_write_nmmap(). stream state is XRUN.
And struct pcm's undderuns value is increase.

Return back undderruns value and let know
pcm's XRUN state in userspace application.

Signed-off-by: pino-kim <sungwon.pino@gmail.com>